### PR TITLE
Packet data length bug fix in client.js

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -20,6 +20,7 @@ export default class {
     this.didSendVersion = false;
     this.logOutgoing = false;
     this.logIncoming = false;
+    this.logDebugging = false;
     this.incomingBuffers = [];
     this.events = new EventEmitter();
     this.events.on(0x00, packetHandlers.encryption)
@@ -43,7 +44,9 @@ export default class {
     }
 
     this.server = getServerFromAddress(address, port);
-    console.log(`Connecting to ${this.server.name}...`);
+    if (this.logDebugging) {
+      console.log(`Connecting to ${this.server.name}...`);
+    }
 
     const socket = new net.Socket();
     socket.on('data', this.receive.bind(this));
@@ -59,7 +62,7 @@ export default class {
     });
   }
 
-  disconnect(socket=this.socket) {
+  disconnect(socket = this.socket) {
     socket.destroy();
   }
 
@@ -81,8 +84,9 @@ export default class {
   }
 
   logIn() {
-    console.log(`Logging in as ${this.username}...`);
-
+    if (this.logDebugging) {
+      console.log(`Logging in as ${this.username}...`);
+    }
     const key1 = random(0xFF);
     const key2 = random(0xFF);
     let clientId = random(0xFFFFFFFF);

--- a/src/client.js
+++ b/src/client.js
@@ -153,7 +153,7 @@ export default class {
     let buffer = Buffer.concat(this.incomingBuffers.splice(0));
 
     while (buffer.length > 3 && buffer[0] === 0xAA) {
-      const length = buffer[1] << 8 | buffer[2] + 3;
+      const length = buffer[1] << 8 + buffer[2] + 3;
 
       if (length > buffer.length) {
         this.incomingBuffers.push(buffer);

--- a/src/client.js
+++ b/src/client.js
@@ -157,7 +157,7 @@ export default class {
     let buffer = Buffer.concat(this.incomingBuffers.splice(0));
 
     while (buffer.length > 3 && buffer[0] === 0xAA) {
-      const length = buffer[1] << 8 + buffer[2] + 3;
+      const length = (buffer[1] << 8 | buffer[2]) + 3;
 
       if (length > buffer.length) {
         this.incomingBuffers.push(buffer);

--- a/src/packet-handlers.js
+++ b/src/packet-handlers.js
@@ -10,7 +10,9 @@ export default {
 
     if (code === 1) {
       client.appVersion -= 1;
-      console.log(`Invalid DA version, possibly too high. Trying again with ${client.appVersion}.`);
+      if (this.logDebugging) {         
+        console.log(`Invalid DA version, possibly too high. Trying again with ${client.appVersion}.`);
+      }
       client.reconnect();
       return;
     }
@@ -19,7 +21,9 @@ export default {
       packet.readByte();
       packet.readString8();  // patch url
       client.appVersion = version;
-      console.log(`Your DA version is too low. Setting DA version to ${version}.`);
+      if (this.logDebugging) {         
+        console.log(`Your DA version is too low. Setting DA version to ${version}.`);
+      }
       client.reconnect();
       return;
     }
@@ -46,12 +50,16 @@ export default {
       case 3: // Invalid name or password
       case 14: // Name does not exist
       case 15: // Incorrect password
-        console.log(`${message}.`);
+        if (this.logDebugging) {         
+          console.log(`${message}.`);
+        }
         client.disconnect();
         break;
       default:
-        console.log(message, `(code ${code})`);
-        console.log('Log in failed. Retrying...');
+        if (this.logDebugging) {         
+          console.log(message, `(code ${code})`);
+          console.log('Log in failed. Retrying...');
+        }
         setTimeout(() => client.reconnect(), 1000)
     }
   },
@@ -80,7 +88,9 @@ export default {
   },
 
   userId(packet, client) {
-    console.log(`Logged into ${client.server.name} as ${client.username}.`);
+    if (this.logDebugging) {         
+      console.log(`Logged into ${client.server.name} as ${client.username}.`);
+    }
     client.send(new Packet(0x2D));
   },
 


### PR DESCRIPTION
Either `(buffer[1] << 8 + buffer[2]) + 3`
or
The Commit made would fix this error

Some packets seem to be getting munged due to the fact that  (buffer[1] << 8) | (buffer[2] + 3) can turn out a lot different than (buffer[1] << 8 + buffer[2] + 3) due to the bitwise or operation resulting in a different length because of overlapping bits.